### PR TITLE
chore(release/proxy-sigv4-backend): publish v0.2.0

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "bundled": true,
   "backstage": {
@@ -51,10 +51,10 @@
   "devDependencies": {
     "@backstage/test-utils": "^1.5.3",
     "@playwright/test": "^1.32.3",
+    "@testing-library/dom": "^8.0.0",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^14.0.0",
-    "@testing-library/dom": "^8.0.0",
     "@types/react-dom": "*",
     "cross-env": "^7.0.0"
   },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/plugins/proxy-sigv4-backend/CHANGELOG.md
+++ b/plugins/proxy-sigv4-backend/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 0.2.0 (2024-04-05)
+
+### Features
+
+- **proxy-sigv4-backend:** add new backend system support ([#4](https://github.com/segmentio/segment-backstage-plugins/issues/4)) ([f497502](https://github.com/segmentio/segment-backstage-plugins/commit/f497502c4306d49c2d600ed393d6b97ab8d40b16))
+- upgrade to backstage 1.25.2 ([#4](https://github.com/segmentio/segment-backstage-plugins/issues/4)) ([04bd05b](https://github.com/segmentio/segment-backstage-plugins/commit/04bd05b6d31ea9a59c0261241a97b8c5efac0c08))

--- a/plugins/proxy-sigv4-backend/package.json
+++ b/plugins/proxy-sigv4-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/backstage-plugin-proxy-sigv4-backend",
   "description": "Backstage backend plugin that configures endpoints for signing and proxying HTTP requests with AWS SigV4",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
Until we get autorelease/autopublish configured, here's how @alecjacobs5401 and I did this one:

1. `npx lerna version --conventional-commits --no-git-tag-version`
2. git foo to create the release commit
3. `npx lerna publish from-package --no-verify-access` (requires OTP)
4. open this PR