### PR TITLE
feat(analytics-module-segment): create the analytics plugin module for segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@
 
 <br>
 
-This repository contains a collection of [Backstage](https://backstage.io) plugins created and maintained by [Twilio Segment](https://segment.com). Installation instructions for each plugin can be found in their respective READMEs.
+This repository contains a collection of [Backstage](https://backstage.io) plugins created and maintained by [Twilio Segment][segment]. Installation instructions for each plugin can be found in their respective READMEs.
 
-| Package                                                                        | Description                                                                                  |
-| ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| [@segment/backstage-plugin-proxy-sigv4-backend](./plugins/proxy-sigv4-backend) | A Backstage backend plugin that proxies requests to AWS services using SigV4 authentication. |
+| Package                                                                                  | Description                                                                                                       |
+| ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| [@segment/backstage-plugin-analytics-module-segment](./plugins/analytics-module-segment) | A Backstage frontend analytics module plugin that provides [Backstage Analytics][analytics] to [Segment][segment] |
+| [@segment/backstage-plugin-proxy-sigv4-backend](./plugins/proxy-sigv4-backend)           | A Backstage backend plugin that proxies requests to AWS services using SigV4 authentication.                      |
 
 <br>
 
@@ -34,3 +35,6 @@ This repository contains a collection of [Backstage](https://backstage.io) plugi
 ## License
 
 Copyright 2023 Twilio Inc. Licensed under the Apache License, Version 2.0: <https://www.apache.org/licenses/LICENSE-2.0>
+
+[analytics]: https://backstage.io/docs/plugins/analytics
+[segment]: https://segment.com

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -1,6 +1,12 @@
 app:
   title: Scaffolded Backstage App
   baseUrl: http://localhost:3000
+  analytics:
+    segment:
+      enabled: true
+      writeKey: ${SEGMENT_WRITE_KEY:-foobar}
+      testMode: true
+      debug: true
 
 organization:
   name: My Company

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -41,6 +41,7 @@
     "@backstage/theme": "^0.5.6",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
+    "@segment/backstage-plugin-analytics-module-segment": "link:../../plugins/analytics-module-segment",
     "history": "^5.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -4,10 +4,13 @@ import {
   ScmAuth,
 } from '@backstage/integration-react';
 import {
+  analyticsApiRef,
   AnyApiFactory,
   configApiRef,
   createApiFactory,
+  identityApiRef,
 } from '@backstage/core-plugin-api';
+import { SegmentAnalytics } from '@segment/backstage-plugin-analytics-module-segment';
 
 export const apis: AnyApiFactory[] = [
   createApiFactory({
@@ -16,4 +19,10 @@ export const apis: AnyApiFactory[] = [
     factory: ({ configApi }) => ScmIntegrationsApi.fromConfig(configApi),
   }),
   ScmAuth.createDefaultApiFactory(),
+  createApiFactory({
+    api: analyticsApiRef,
+    deps: { configApi: configApiRef, identityApi: identityApiRef },
+    factory: ({ configApi, identityApi }) =>
+      SegmentAnalytics.fromConfig(configApi, { identityApi }),
+  }),
 ];

--- a/plugins/analytics-module-segment/.eslintrc.js
+++ b/plugins/analytics-module-segment/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/analytics-module-segment/README.md
+++ b/plugins/analytics-module-segment/README.md
@@ -117,7 +117,7 @@ export const apis: AnyApiFactory[] = [
 
 #### Optional: Prevent user identification
 
-If you wish to chose to identify Backstage users in analytics events, simply neglect to provide the `identityApi` when initializing the `SegmentAnalytics` API.
+If you choose not to identify Backstage users in analytics events, simply neglect to provide the `identityApi` when initializing the `SegmentAnalytics` API.
 
 ```ts
 // packages/app/src/apis.ts

--- a/plugins/analytics-module-segment/README.md
+++ b/plugins/analytics-module-segment/README.md
@@ -1,0 +1,210 @@
+# Analytics Module: Segment
+
+This plugin provides an opinionated implementation of the Backstage Analytics
+API for [Segment][segment]. Once installed and configured, analytics events will
+be sent to the configured Segment Workspace as your users navigate and use your Backstage instance.
+
+## Requirements
+
+This plugin requires an active workspace with [Segment][segment]. Please reference the [Getting Started Guide][getting-started] to get set up before proceeding.
+
+## Installation
+
+### Install the plugin package in your Backstage app:
+
+```sh
+# From your Backstage root directory
+yarn --cwd packages/app add @segment/backstage-plugin-analytics-module-segment
+```
+
+### Wire up the API implementation to your App:
+
+```ts
+// packages/app/src/apis.ts
+import {
+  analyticsApiRef,
+  configApiRef,
+  identityApiRef,
+} from '@backstage/core-plugin-api';
+import { SegmentAnalytics } from '@segment/backstage-plugin-analytics-module-segment';
+
+export const apis: AnyApiFactory[] = [
+  // Instantiate and register the SegmentAnalytics API Implementation.
+  createApiFactory({
+    api: analyticsApiRef,
+    deps: { configApi: configApiRef, identityApi: identityApiRef },
+    factory: ({ configApi, identityApi }) =>
+      SegmentAnalytics.fromConfig(configApi, {
+        identityApi,
+      }),
+  }),
+];
+```
+
+#### Optional: Configure a user transform
+
+By default, this analytics plugin [identifies][identify] the user taking actions as the logged in Backstage User's entity reference string (e.g. `user:development/guest`). Currently, no other information is provided to the identify call.
+
+To anonymize users, a `userIdTransform` can be provided in one of two ways:
+
+1. The string value `sha-256`
+2. A custom transformation function that matches the contract of `(userEntityRef: string) => Promise<string>`
+
+If `sha-256` is provided, the user entity reference will be pseudonymized into a sha256 string value.
+
+```ts
+// packages/app/src/apis.ts
+import {
+  analyticsApiRef,
+  configApiRef,
+  identityApiRef,
+} from '@backstage/core-plugin-api';
+import { SegmentAnalytics } from '@segment/backstage-plugin-analytics-module-segment';
+
+export const apis: AnyApiFactory[] = [
+  // Instantiate and register the SegmentAnalytics API Implementation.
+  createApiFactory({
+    api: analyticsApiRef,
+    deps: { configApi: configApiRef, identityApi: identityApiRef },
+    factory: ({ configApi, identityApi }) =>
+      SegmentAnalytics.fromConfig(configApi, {
+        identityApi,
+        userIdTransform: 'sha-256',
+      }),
+  }),
+];
+```
+
+For enhanced security, providing a custom transformation function can be used to hash the value in any means desired.
+
+```ts
+// packages/app/src/apis.ts
+import {
+  analyticsApiRef,
+  configApiRef,
+  identityApiRef,
+} from '@backstage/core-plugin-api';
+import { SegmentAnalytics } from '@segment/backstage-plugin-analytics-module-segment';
+
+export const apis: AnyApiFactory[] = [
+  // Instantiate and register the SegmentAnalytics API Implementation.
+  createApiFactory({
+    api: analyticsApiRef,
+    deps: { configApi: configApiRef, identityApi: identityApiRef },
+    factory: ({ configApi, identityApi }) =>
+      SegmentAnalytics.fromConfig(configApi, {
+        identityApi,
+        async userIdTransform(userEntityRef: string) {
+          const salt = configApi.getString(
+            'custom.config.analytics.userIdSalt',
+          );
+          const textToChars = (text: string) =>
+            text.split('').map(c => c.charCodeAt(0));
+          const byteHex = (n: number) =>
+            ('0' + Number(n).toString(16)).substring(-2);
+          const applySaltToChar = (code: number) =>
+            textToChars(salt).reduce((a, b) => a ^ b, code);
+
+          return textToChars(userEntityRef)
+            .map(applySaltToChar)
+            .map(byteHex)
+            .join('');
+        },
+      }),
+  }),
+];
+```
+
+#### Optional: Prevent user identification
+
+If you wish to chose to identify Backstage users in analytics events, simply neglect to provide the `identityApi` when initializing the `SegmentAnalytics` API.
+
+```ts
+// packages/app/src/apis.ts
+import { analyticsApiRef, configApiRef } from '@backstage/core-plugin-api';
+import { SegmentAnalytics } from '@segment/backstage-plugin-analytics-module-segment';
+
+export const apis: AnyApiFactory[] = [
+  // Instantiate and register the SegmentAnalytics API Implementation.
+  createApiFactory({
+    api: analyticsApiRef,
+    deps: { configApi: configApiRef },
+    factory: ({ configApi }) => SegmentAnalytics.fromConfig(configApi),
+  }),
+];
+```
+
+Doing so will allow analytic events to continue to be sent to Segment, just with the the events being attributed to [anonymous user IDs][anonymous-ids].
+
+### Configure the plugin in your `app-config.yaml`:
+
+The following is the minimum configuration required to start sending analytics
+events to Segment. The only requirement is the [write key][write-key] for the [Analytics.js Source][analytics.js-source] that was created for your Backstage instance.
+
+```yaml
+# app-config.yaml
+app:
+  analytics:
+    segment:
+      writeKey: abcABCfooBARtestKEY
+```
+
+## Configuration
+
+### Disabling
+
+In some pre-production environments, it may not be prudent to load the Segment Analytics plugin at all. In those cases, you can explicitly disable analytics through app configuration:
+
+```yaml
+# app-config.yaml
+app:
+  analytics:
+    segment:
+      enabled: false # Prevent the analytics instance from loading
+      writeKey: abcABCfooBARtestKEY # write key is still required in app-config
+```
+
+### Debugging and Testing
+
+In pre-production environments, you may wish to set additional configurations
+to turn off reporting to Analytics and/or print debug statements to the
+console. In those cases, you can explicitly disable analytics through app configuration:
+
+```yaml
+app:
+  analytics:
+    segment:
+      writeKey: abcABCfooBARtestKEY
+      testMode: true # Prevents data being sent to Segment and logs what would have been sent instead
+      debug: true # Configure debug on the Analytics module and write the Backstage analytics event to the web console
+```
+
+### Analytics agent options
+
+Additional configuration is available to configure the Analytics.js agent as follows:
+
+```yaml
+app:
+  analytics:
+    segment:
+      writeKey: abcABCfooBARtestKEY
+      agent:
+        # Disable storing any data on the client-side via cookies or localstorage
+        disableClientPersistence: true
+        # Disables automatically converting ISO string event properties into Dates.
+        disableAutoISOConversion: true
+        # Whether or not to capture page context early so that it is always up-to-date.
+        initialPageView: true
+```
+
+> [!NOTE]\
+> The `testMode` and `debug` configuration fields work independently of each other.
+> If `debug` is `true` and `testMode` is `false`, analytics events will still be sent to Segment
+> and debug information will be written to the console still.
+
+[segment]: https://segment.com/
+[getting-started]: https://segment.com/docs/getting-started/
+[write-key]: https://segment.com/docs/connections/find-writekey/
+[analytics.js-source]: https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/
+[identify]: https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/#identify
+[anonymous-ids]: https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/identity/#anonymous-ids

--- a/plugins/analytics-module-segment/config.d.ts
+++ b/plugins/analytics-module-segment/config.d.ts
@@ -1,0 +1,72 @@
+export interface Config {
+  app: {
+    analytics: {
+      segment: {
+        /**
+         * Controls whether the Segment Analytics module is enabled.
+         * Defaults to true.
+         *
+         * @visibility frontend
+         */
+        enabled?: boolean;
+
+        /**
+         * Segment Analytics Write Key. Reference https://segment.com/docs/connections/find-writekey/
+         * to find your write key
+         *
+         * @visibility frontend
+         */
+        writeKey: string;
+
+        /**
+         * Whether to log analytics debug statements to the console.
+         * Defaults to false.
+         *
+         * @visibility frontend
+         */
+        debug?: boolean;
+
+        /**
+         * Prevents events from actually being sent when set to true. Defaults
+         * to false.
+         *
+         * @visibility frontend
+         */
+        testMode?: boolean;
+
+        /**
+         * Configuration options for the Segment Analytics agent.
+         *
+         * @visibility frontend
+         */
+        agent?: {
+          /**
+           * Disables storing any data on the client-side via cookies or localstorage.
+           * Defaults to false.
+           *
+           * @visibility frontend
+           */
+          disableClientPersistence?: boolean;
+
+          /**
+           * Disables automatically converting ISO string event properties into Dates.
+           * ISO string to Date conversions occur right before sending events to a classic device mode integration,
+           * after any destination middleware have been ran.
+           * Defaults to false.
+           *
+           * @visibility frontend
+           */
+          disableAutoISOConversion?: boolean;
+
+          /**
+           * Whether or not to capture page context early so that it is always up-to-date.
+           * Defaults to false.
+           *
+           * @visibility frontend
+           */
+          initialPageView?: boolean;
+        };
+      };
+    };
+  };
+}

--- a/plugins/analytics-module-segment/config.d.ts
+++ b/plugins/analytics-module-segment/config.d.ts
@@ -19,7 +19,7 @@ export interface Config {
         writeKey: string;
 
         /**
-         * Whether to log analytics debug statements to the console.
+         * Whether to log analytics debug statements and events to the console. Does not prevent sending of events.
          * Defaults to false.
          *
          * @visibility frontend
@@ -27,8 +27,8 @@ export interface Config {
         debug?: boolean;
 
         /**
-         * Prevents events from actually being sent when set to true. Defaults
-         * to false.
+         * Prevents events from actually being sent and instead logged as console output when set to true.
+         * Defaults to false.
          *
          * @visibility frontend
          */

--- a/plugins/analytics-module-segment/dev/Playground.tsx
+++ b/plugins/analytics-module-segment/dev/Playground.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Link } from '@backstage/core-components';
+
+export const Playground = () => {
+  return (
+    <>
+      <Link to="#clicked">Click Here</Link>
+    </>
+  );
+};

--- a/plugins/analytics-module-segment/dev/index.tsx
+++ b/plugins/analytics-module-segment/dev/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {
+  analyticsApiRef,
+  configApiRef,
+  identityApiRef,
+} from '@backstage/core-plugin-api';
+import { createDevApp } from '@backstage/dev-utils';
+
+import { Playground } from './Playground';
+import { SegmentAnalytics } from '../src';
+
+createDevApp()
+  .registerApi({
+    api: analyticsApiRef,
+    deps: { configApi: configApiRef, identityApi: identityApiRef },
+    factory: ({ configApi, identityApi }) =>
+      SegmentAnalytics.fromConfig(configApi, {
+        identityApi,
+      }),
+  })
+  .addPage({
+    path: '/segment',
+    title: 'Segment Playground',
+    element: <Playground />,
+  })
+  .render();

--- a/plugins/analytics-module-segment/package.json
+++ b/plugins/analytics-module-segment/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@segment/backstage-plugin-analytics-module-segment",
+  "description": "Backstage analytics module plugin for Segment",
+  "version": "0.0.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin-module",
+    "pluginId": "app",
+    "pluginPackage": "@backstage/plugin-app-backend"
+  },
+  "repository": {
+    "type": "git",
+    "url": "github:segmentio/segment-backstage-plugins",
+    "directory": "plugins/analytics-module-segment"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "start": "backstage-cli package start",
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@segment/analytics-next": "^1.72.1"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.27.0",
+    "@backstage/config": "^1.2.0",
+    "@backstage/core-app-api": "^1.14.2",
+    "@backstage/core-components": "^0.14.7",
+    "@backstage/core-plugin-api": "^1.9.3",
+    "@backstage/dev-utils": "^1.0.37",
+    "@backstage/frontend-plugin-api": "^0.7.0",
+    "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
+  },
+  "files": [
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
+}

--- a/plugins/analytics-module-segment/src/apis/implementations/AnalyticsApi/SegmentAnalytics.test.ts
+++ b/plugins/analytics-module-segment/src/apis/implementations/AnalyticsApi/SegmentAnalytics.test.ts
@@ -1,0 +1,476 @@
+import { ConfigReader } from '@backstage/config';
+import type { IdentityApi } from '@backstage/core-plugin-api';
+
+import { AnalyticsBrowser } from '@segment/analytics-next';
+
+import {
+  SegmentAnalytics,
+  type UserIdTransformOption,
+} from './SegmentAnalytics';
+
+import { mockAnalyticsBrowser } from '../../../setupTests';
+
+const mockIdentityApi: jest.Mocked<IdentityApi> = {
+  getBackstageIdentity: jest.fn().mockResolvedValue({
+    type: 'user',
+    userEntityRef: 'user:development/guest',
+    ownershipEntityRefs: ['user:development/guest'],
+  }),
+} as any as jest.Mocked<IdentityApi>;
+
+const flushPromises = async () => new Promise(res => process.nextTick(res));
+
+const fnLog = jest.spyOn(global.console, 'log').mockImplementation();
+
+describe('SegmentAnalytics', () => {
+  let analytics: SegmentAnalytics;
+
+  const buildAnalytics = async ({
+    config,
+    userIdTransform,
+  }: {
+    config: ConfigReader;
+    userIdTransform?: UserIdTransformOption;
+  }) => {
+    const sa = SegmentAnalytics.fromConfig(config, {
+      identityApi: mockIdentityApi,
+      userIdTransform,
+    });
+
+    await flushPromises();
+
+    return sa;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('throws error if no config is provided', async () => {
+    const config = new ConfigReader({
+      app: {},
+    });
+    await expect(buildAnalytics({ config })).rejects.toThrow(
+      "Missing required config value at 'app.analytics.segment.writeKey' in 'mock-config'",
+    );
+  });
+
+  it('throws error if no writeKey is provided', async () => {
+    const config = new ConfigReader({
+      app: {
+        analytics: {
+          segment: {
+            debug: true,
+            enabled: true,
+            testMode: true,
+            agent: {
+              disableClientPersistence: true,
+              disableAutoISOConversion: true,
+              initialPageView: true,
+            },
+          },
+        },
+      },
+    });
+    await expect(buildAnalytics({ config })).rejects.toThrow(
+      "Missing required config value at 'app.analytics.segment.writeKey' in 'mock-config'",
+    );
+  });
+
+  describe('when enabled', () => {
+    beforeEach(async () => {
+      analytics = await buildAnalytics({
+        config: new ConfigReader({
+          app: {
+            analytics: {
+              segment: {
+                writeKey: 'abcABCfooBARtestKEY',
+              },
+            },
+          },
+        }),
+      });
+      fnLog.mockClear();
+    });
+
+    it('creates the analytics client not in debug mode', async () => {
+      expect(AnalyticsBrowser.load).toHaveBeenCalledWith(
+        { writeKey: 'abcABCfooBARtestKEY' },
+        {
+          disable: false,
+        },
+      );
+      expect(mockAnalyticsBrowser.identify).toHaveBeenCalledWith(
+        'user:development/guest',
+      );
+      expect(mockAnalyticsBrowser.debug).toHaveBeenCalledWith(false);
+    });
+
+    it('handles navigate events', () => {
+      analytics.captureEvent({
+        action: 'navigate',
+        subject: '/test',
+        context: { pluginId: 'test', extensionId: 'test' },
+      });
+
+      expect(mockAnalyticsBrowser.page).toHaveBeenCalledWith({
+        action: 'navigate',
+        category: 'test',
+        subject: '/test',
+        pluginId: 'test',
+        extensionId: 'test',
+        additionalContext: {},
+      });
+      expect(fnLog).not.toHaveBeenCalled();
+    });
+
+    it('handles create events', () => {
+      analytics.captureEvent({
+        action: 'create',
+        subject: 'new Template',
+        context: {
+          pluginId: 'scaffolder',
+          routeRef: 'unknown',
+          extension: 'scaffolder',
+        },
+      });
+
+      expect(mockAnalyticsBrowser.track).toHaveBeenCalledWith('new Template', {
+        action: 'create',
+        category: 'scaffolder',
+        subject: 'new Template',
+        pluginId: 'scaffolder',
+        extensionId: 'scaffolder',
+        routeRef: 'unknown',
+        additionalContext: {},
+      });
+      expect(fnLog).not.toHaveBeenCalled();
+    });
+
+    it.each(['click', 'search', 'discover', 'not-found'])(
+      'handles key event %s',
+      action => {
+        analytics.captureEvent({
+          action,
+          subject: 'CI/CD',
+          context: { pluginId: 'component', extensionId: '' },
+        });
+
+        expect(mockAnalyticsBrowser.track).toHaveBeenCalledWith(action, {
+          action,
+          category: 'app',
+          subject: 'CI/CD',
+          pluginId: 'component',
+          additionalContext: {},
+        });
+        expect(fnLog).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  describe('when not enabled', () => {
+    beforeEach(async () => {
+      analytics = await buildAnalytics({
+        config: new ConfigReader({
+          app: {
+            analytics: {
+              segment: {
+                writeKey: 'abcABCfooBARtestKEY',
+                enabled: false,
+                debug: true,
+                testMode: true,
+                agent: {
+                  disableClientPersistence: true,
+                  disableAutoISOConversion: true,
+                  initialPageView: true,
+                },
+              },
+            },
+          },
+        }),
+      });
+    });
+
+    it('does not initialize SegmentAnalytics', async () => {
+      expect(AnalyticsBrowser.load).not.toHaveBeenCalled();
+      expect(mockAnalyticsBrowser.identify).not.toHaveBeenCalled();
+      expect(fnLog).toHaveBeenCalledWith(
+        'backstage-plugin-analytics-module-segment:',
+        'Segment Analytics disabled',
+      );
+    });
+
+    it('does not handle any sent events', async () => {
+      fnLog.mockClear();
+
+      analytics.captureEvent({
+        action: 'navigate',
+        subject: '/test',
+        context: { pluginId: 'test', extensionId: 'test' },
+      });
+
+      expect(mockAnalyticsBrowser.page).not.toHaveBeenCalled();
+      expect(fnLog).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with testMode enabled', () => {
+    beforeEach(async () => {
+      analytics = await buildAnalytics({
+        config: new ConfigReader({
+          app: {
+            analytics: {
+              segment: {
+                writeKey: 'abcABCfooBARtestKEY',
+                testMode: true,
+              },
+            },
+          },
+        }),
+      });
+    });
+
+    it('disables analytics while in test mode', async () => {
+      expect(AnalyticsBrowser.load).toHaveBeenCalledWith(
+        { writeKey: 'abcABCfooBARtestKEY' },
+        {
+          disable: true,
+        },
+      );
+      expect(mockAnalyticsBrowser.identify).not.toHaveBeenCalled();
+      expect(fnLog).toHaveBeenCalledWith('identify("user:development/guest")');
+      expect(mockAnalyticsBrowser.debug).toHaveBeenCalledWith(false);
+    });
+
+    it('logs analytics actions that would be sent', async () => {
+      fnLog.mockClear();
+
+      analytics.captureEvent({
+        action: 'navigate',
+        subject: '/test',
+        context: { pluginId: 'test', extensionId: 'test' },
+      });
+
+      expect(mockAnalyticsBrowser.page).not.toHaveBeenCalled();
+      expect(fnLog).toHaveBeenNthCalledWith(1, 'analytics.page()', {
+        action: 'navigate',
+        category: 'test',
+        subject: '/test',
+        pluginId: 'test',
+        extensionId: 'test',
+        additionalContext: {},
+      });
+
+      analytics.captureEvent({
+        action: 'create',
+        subject: 'new Template',
+        context: {
+          pluginId: 'scaffolder',
+          routeRef: 'unknown',
+          extension: 'scaffolder',
+        },
+      });
+
+      expect(mockAnalyticsBrowser.track).not.toHaveBeenCalled();
+      expect(fnLog).toHaveBeenNthCalledWith(
+        2,
+        'analytics.track("new Template")',
+        {
+          action: 'create',
+          category: 'scaffolder',
+          subject: 'new Template',
+          pluginId: 'scaffolder',
+          extensionId: 'scaffolder',
+          routeRef: 'unknown',
+          additionalContext: {},
+        },
+      );
+
+      analytics.captureEvent({
+        action: 'click',
+        subject: 'CI/CD',
+        context: { pluginId: 'component', extensionId: '' },
+      });
+
+      expect(mockAnalyticsBrowser.track).not.toHaveBeenCalled();
+      expect(fnLog).toHaveBeenNthCalledWith(3, 'analytics.track("click")', {
+        action: 'click',
+        category: 'app',
+        subject: 'CI/CD',
+        pluginId: 'component',
+        additionalContext: {},
+      });
+    });
+  });
+
+  describe('with debug enabled', () => {
+    beforeEach(async () => {
+      analytics = await buildAnalytics({
+        config: new ConfigReader({
+          app: {
+            analytics: {
+              segment: {
+                writeKey: 'abcABCfooBARtestKEY',
+                debug: true,
+              },
+            },
+          },
+        }),
+      });
+      fnLog.mockClear();
+    });
+
+    it('enables debug mode', async () => {
+      expect(AnalyticsBrowser.load).toHaveBeenCalledWith(
+        { writeKey: 'abcABCfooBARtestKEY' },
+        { disable: false },
+      );
+      expect(mockAnalyticsBrowser.identify).toHaveBeenCalledWith(
+        'user:development/guest',
+      );
+      expect(mockAnalyticsBrowser.debug).toHaveBeenCalledWith(true);
+    });
+
+    it('logs analytics actions that would be sent', async () => {
+      analytics.captureEvent({
+        action: 'navigate',
+        subject: '/test',
+        context: { pluginId: 'test', extensionId: 'test' },
+      });
+
+      expect(mockAnalyticsBrowser.page).toHaveBeenCalledWith({
+        action: 'navigate',
+        category: 'test',
+        subject: '/test',
+        pluginId: 'test',
+        extensionId: 'test',
+        additionalContext: {},
+      });
+      expect(fnLog).toHaveBeenNthCalledWith(
+        1,
+        'backstage-plugin-analytics-module-segment:',
+        'Capturing event',
+        {
+          action: 'navigate',
+          subject: '/test',
+          context: { pluginId: 'test', extensionId: 'test' },
+        },
+      );
+
+      analytics.captureEvent({
+        action: 'create',
+        subject: 'new Template',
+        context: {
+          pluginId: 'scaffolder',
+          routeRef: 'unknown',
+          extension: 'scaffolder',
+        },
+      });
+
+      expect(mockAnalyticsBrowser.track).toHaveBeenNthCalledWith(
+        1,
+        'new Template',
+        {
+          action: 'create',
+          category: 'scaffolder',
+          subject: 'new Template',
+          pluginId: 'scaffolder',
+          extensionId: 'scaffolder',
+          routeRef: 'unknown',
+          additionalContext: {},
+        },
+      );
+      expect(fnLog).toHaveBeenNthCalledWith(
+        2,
+        'backstage-plugin-analytics-module-segment:',
+        'Capturing event',
+        {
+          action: 'create',
+          subject: 'new Template',
+          context: {
+            pluginId: 'scaffolder',
+            routeRef: 'unknown',
+            extension: 'scaffolder',
+          },
+        },
+      );
+
+      analytics.captureEvent({
+        action: 'click',
+        subject: 'CI/CD',
+        context: { pluginId: 'component', extensionId: '' },
+      });
+
+      expect(mockAnalyticsBrowser.track).toHaveBeenNthCalledWith(2, 'click', {
+        action: 'click',
+        category: 'app',
+        subject: 'CI/CD',
+        pluginId: 'component',
+        additionalContext: {},
+      });
+
+      expect(fnLog).toHaveBeenNthCalledWith(
+        3,
+        'backstage-plugin-analytics-module-segment:',
+        'Capturing event',
+        {
+          action: 'click',
+          subject: 'CI/CD',
+          context: { pluginId: 'component', extensionId: '' },
+        },
+      );
+    });
+  });
+
+  describe('with userIdTransform', () => {
+    describe('as sha-256', () => {
+      beforeEach(async () => {
+        analytics = await buildAnalytics({
+          config: new ConfigReader({
+            app: {
+              analytics: {
+                segment: {
+                  writeKey: 'abcABCfooBARtestKEY',
+                },
+              },
+            },
+          }),
+          userIdTransform: 'sha-256',
+        });
+        fnLog.mockClear();
+      });
+
+      it('sha256 hashes the user id on identify', async () => {
+        expect(mockAnalyticsBrowser.identify).toHaveBeenCalledWith(
+          '757365723a646576656c6f706d656e742f6775657374',
+        );
+      });
+    });
+
+    describe('with a custom userIdTransform function', () => {
+      beforeEach(async () => {
+        analytics = await buildAnalytics({
+          config: new ConfigReader({
+            app: {
+              analytics: {
+                segment: {
+                  writeKey: 'abcABCfooBARtestKEY',
+                },
+              },
+            },
+          }),
+          async userIdTransform(userEntityRef) {
+            return `hello there fellow ${userEntityRef}`;
+          },
+        });
+        fnLog.mockClear();
+      });
+
+      it('sha256 hashes the user id on identify', async () => {
+        expect(mockAnalyticsBrowser.identify).toHaveBeenCalledWith(
+          'hello there fellow user:development/guest',
+        );
+      });
+    });
+  });
+});

--- a/plugins/analytics-module-segment/src/apis/implementations/AnalyticsApi/SegmentAnalytics.ts
+++ b/plugins/analytics-module-segment/src/apis/implementations/AnalyticsApi/SegmentAnalytics.ts
@@ -1,0 +1,180 @@
+import type { Config } from '@backstage/config';
+import type {
+  AnalyticsApi,
+  AnalyticsEvent,
+  IdentityApi,
+} from '@backstage/core-plugin-api';
+import type {
+  AnalyticsApi as NewAnalyicsApi,
+  AnalyticsEvent as NewAnalyticsEvent,
+} from '@backstage/frontend-plugin-api';
+
+import { AnalyticsBrowser } from '@segment/analytics-next';
+
+type UserIdTransform = (userEntityRef: string) => Promise<string>;
+export type UserIdTransformOption = 'sha-256' | UserIdTransform;
+const defaultUserIdTransform: UserIdTransform = async (userEntityRef: string) =>
+  userEntityRef;
+
+const hash = async (value: string): Promise<string> => {
+  const digest = await window.crypto.subtle.digest(
+    'sha-256',
+    new TextEncoder().encode(value),
+  );
+  const hashArray = Array.from(new Uint8Array(digest));
+  return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+};
+
+type AgentOptions = {
+  disableClientPersistence?: boolean;
+  disableAutoISOConversion?: boolean;
+  initialPageView?: boolean;
+};
+
+export class SegmentAnalytics implements AnalyticsApi, NewAnalyicsApi {
+  readonly #agent?: AnalyticsBrowser;
+  readonly #debug: boolean;
+  readonly #enabled: boolean;
+  readonly #testMode: boolean;
+
+  private constructor({
+    identityApi,
+    userIdTransform,
+    writeKey,
+    debug,
+    enabled,
+    testMode,
+    agentOptions,
+  }: {
+    identityApi?: IdentityApi;
+    userIdTransform: UserIdTransform;
+    writeKey: string;
+    debug: boolean;
+    enabled: boolean;
+    testMode: boolean;
+    agentOptions: AgentOptions;
+  }) {
+    this.#debug = debug;
+    this.#enabled = enabled;
+    this.#testMode = testMode;
+
+    if (this.#enabled) {
+      this.#agent = AnalyticsBrowser.load(
+        { writeKey },
+        { ...agentOptions, disable: !enabled || testMode },
+      );
+
+      this.#agent.debug(this.#debug);
+      if (identityApi) {
+        identityApi.getBackstageIdentity().then(async ({ userEntityRef }) => {
+          const userId = await userIdTransform(userEntityRef);
+          if (this.#testMode) {
+            // eslint-disable-next-line no-console
+            console.log(`identify("${userId}")`);
+          } else {
+            this.#agent?.identify(userId);
+          }
+          return;
+        });
+      }
+    } else {
+      this.debug('Segment Analytics disabled');
+    }
+  }
+
+  static fromConfig(
+    config: Config,
+    options: {
+      identityApi?: IdentityApi;
+      userIdTransform?: UserIdTransformOption;
+    } = {},
+  ) {
+    let userIdTransform = defaultUserIdTransform;
+    if (options.userIdTransform === 'sha-256') {
+      userIdTransform = hash;
+    } else if (options.userIdTransform) {
+      userIdTransform = options.userIdTransform;
+    }
+
+    const writeKey = config.getString('app.analytics.segment.writeKey');
+    const enabled =
+      config.getOptionalBoolean('app.analytics.segment.enabled') ?? true;
+    const debug =
+      config.getOptionalBoolean('app.analytics.segment.debug') ?? false;
+    const testMode =
+      config.getOptionalBoolean('app.analytics.segment.testMode') ?? false;
+    const agentOptions =
+      config.getOptional<AgentOptions>('app.analytics.segment.agent') ?? {};
+
+    return new SegmentAnalytics({
+      identityApi: options.identityApi,
+      userIdTransform,
+      writeKey,
+      enabled,
+      debug,
+      agentOptions,
+      testMode,
+    });
+  }
+
+  captureEvent(event: AnalyticsEvent | NewAnalyticsEvent) {
+    if (this.#enabled) {
+      this.debug('Capturing event', event);
+      const { action, subject, value, context, attributes } = event;
+      const {
+        routeRef,
+        pluginId,
+        extension,
+        extensionId,
+        ...additionalContext
+      } = context;
+      const normalizedExtensionId = extensionId || extension;
+      const category = normalizedExtensionId
+        ? String(normalizedExtensionId)
+        : 'app';
+      const eventProperties = {
+        subject,
+        action,
+        value,
+        routeRef,
+        pluginId,
+        extensionId: normalizedExtensionId,
+        category,
+        attributes,
+        additionalContext,
+      };
+      switch (event.action) {
+        case 'navigate':
+          if (this.#testMode) {
+            // eslint-disable-next-line no-console
+            console.log(`analytics.page()`, eventProperties);
+          } else {
+            this.#agent?.page(eventProperties);
+          }
+          break;
+        case 'create':
+          if (this.#testMode) {
+            // eslint-disable-next-line no-console
+            console.log(`analytics.track("${event.subject}")`, eventProperties);
+          } else {
+            this.#agent?.track(event.subject, eventProperties);
+          }
+          break;
+        default:
+          if (this.#testMode) {
+            // eslint-disable-next-line no-console
+            console.log(`analytics.track("${event.action}")`, eventProperties);
+          } else {
+            this.#agent?.track(event.action, eventProperties);
+          }
+      }
+    }
+  }
+
+  private debug(...data: any[]) {
+    if (this.#debug) {
+      // eslint-disable-next-line no-console
+      console.log('backstage-plugin-analytics-module-segment:', ...data);
+    }
+  }
+}

--- a/plugins/analytics-module-segment/src/apis/implementations/AnalyticsApi/index.ts
+++ b/plugins/analytics-module-segment/src/apis/implementations/AnalyticsApi/index.ts
@@ -1,0 +1,1 @@
+export { SegmentAnalytics } from './SegmentAnalytics';

--- a/plugins/analytics-module-segment/src/apis/implementations/index.ts
+++ b/plugins/analytics-module-segment/src/apis/implementations/index.ts
@@ -1,0 +1,1 @@
+export * from './AnalyticsApi';

--- a/plugins/analytics-module-segment/src/apis/index.ts
+++ b/plugins/analytics-module-segment/src/apis/index.ts
@@ -1,0 +1,1 @@
+export * from './implementations';

--- a/plugins/analytics-module-segment/src/index.ts
+++ b/plugins/analytics-module-segment/src/index.ts
@@ -1,0 +1,1 @@
+export { SegmentAnalytics } from './apis';

--- a/plugins/analytics-module-segment/src/setupTests.ts
+++ b/plugins/analytics-module-segment/src/setupTests.ts
@@ -1,0 +1,40 @@
+import { AnalyticsBrowser } from '@segment/analytics-next';
+
+// eslint-disable-next-line no-restricted-imports
+import { TextEncoder } from 'util';
+
+// Mock browser crypto.subtle.digest method for sha-256 hashing.
+Object.defineProperty(global.self, 'crypto', {
+  value: {
+    subtle: {
+      digest: (_algo: string, data: Uint8Array): ArrayBuffer => data.buffer,
+    },
+  },
+});
+
+// Also used in browser-based APIs for hashing.
+Object.defineProperty(global.self, 'TextEncoder', {
+  value: TextEncoder,
+});
+
+// partial mock of AnalyticsBrowser to facilitate
+export const mockAnalyticsBrowser: jest.Mocked<AnalyticsBrowser> = {
+  load: jest.fn(),
+  debug: jest.fn(),
+  identify: jest.fn(),
+  page: jest.fn(),
+  track: jest.fn(),
+} as any as jest.Mocked<AnalyticsBrowser>;
+
+jest.mock('@segment/analytics-next', () => {
+  const fnAnalyticsBrowser = jest
+    .fn()
+    .mockImplementation(() => mockAnalyticsBrowser);
+  // @ts-ignore
+  fnAnalyticsBrowser.load = jest
+    .fn()
+    .mockImplementation(() => mockAnalyticsBrowser);
+  return {
+    AnalyticsBrowser: fnAnalyticsBrowser,
+  };
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2578,7 +2578,7 @@
     "@types/react" "^16.13.1 || ^17.0.0"
     lodash "^4.17.21"
 
-"@backstage/core-components@^0.14.10", "@backstage/core-components@^0.14.9":
+"@backstage/core-components@^0.14.10", "@backstage/core-components@^0.14.7", "@backstage/core-components@^0.14.9":
   version "0.14.10"
   resolved "https://registry.yarnpkg.com/@backstage/core-components/-/core-components-0.14.10.tgz#944fe655220be8af9fde0deeafe16f9ce7fe1924"
   integrity sha512-RAEIQsJimokQDF0eAuRXSZreo2vjhf4a2tlMbi/edPRaGk4nTOHH7q6V7qLqqX9spTzS0bBAhkuif/v96shJuw==
@@ -2632,6 +2632,24 @@
     "@backstage/version-bridge" "^1.0.8"
     "@types/react" "^16.13.1 || ^17.0.0 || ^18.0.0"
     history "^5.0.0"
+
+"@backstage/dev-utils@^1.0.37":
+  version "1.0.37"
+  resolved "https://registry.yarnpkg.com/@backstage/dev-utils/-/dev-utils-1.0.37.tgz#a9e3a3a6d4a49bc75a79e682a1e4c2c69de5f2c9"
+  integrity sha512-e1W7Hw/tpAVKb5fcw/pHSZjAOFRKSl9gXdePvGLxZvDMeOKlROhRCv0bjHfIvhQ7GiKGjemY8SDJOvHM0YZYiA==
+  dependencies:
+    "@backstage/app-defaults" "^1.5.10"
+    "@backstage/catalog-model" "^1.6.0"
+    "@backstage/core-app-api" "^1.14.2"
+    "@backstage/core-components" "^0.14.10"
+    "@backstage/core-plugin-api" "^1.9.3"
+    "@backstage/integration-react" "^1.1.30"
+    "@backstage/plugin-catalog-react" "^1.12.3"
+    "@backstage/theme" "^0.5.6"
+    "@material-ui/core" "^4.12.2"
+    "@material-ui/icons" "^4.9.1"
+    "@types/react" "^16.13.1 || ^17.0.0 || ^18.0.0"
+    react-use "^17.2.4"
 
 "@backstage/e2e-test-utils@^0.1.1":
   version "0.1.1"
@@ -5317,6 +5335,18 @@
   dependencies:
     "@lezer/common" "^1.0.0"
 
+"@lukeed/csprng@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@lukeed/csprng/-/csprng-1.1.0.tgz#1e3e4bd05c1cc7a0b2ddbd8a03f39f6e4b5e6cfe"
+  integrity sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==
+
+"@lukeed/uuid@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@lukeed/uuid/-/uuid-2.0.1.tgz#4f6c34259ee0982a455e1797d56ac27bb040fd74"
+  integrity sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==
+  dependencies:
+    "@lukeed/csprng" "^1.1.0"
+
 "@manypkg/find-root@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@manypkg/find-root/-/find-root-1.1.0.tgz#a62d8ed1cd7e7d4c11d9d52a8397460b5d4ad29f"
@@ -6991,6 +7021,51 @@
     "@sagold/json-pointer" "^5.1.2"
     ebnf "^1.9.1"
 
+"@segment/analytics-core@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@segment/analytics-core/-/analytics-core-1.6.0.tgz#f59cdc45a4408a09fdae77910f5a0b43833e8af8"
+  integrity sha512-bn9X++IScUfpT7aJGjKU/yJAu/Ko2sYD6HsKA70Z2560E89x30pqgqboVKY8kootvQnT4UKCJiUr5NDMgjmWdQ==
+  dependencies:
+    "@lukeed/uuid" "^2.0.0"
+    "@segment/analytics-generic-utils" "1.2.0"
+    dset "^3.1.2"
+    tslib "^2.4.1"
+
+"@segment/analytics-generic-utils@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz#9232162d6dbcd18501813fdff18035ce48fd24bf"
+  integrity sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==
+  dependencies:
+    tslib "^2.4.1"
+
+"@segment/analytics-next@^1.72.1":
+  version "1.72.1"
+  resolved "https://registry.yarnpkg.com/@segment/analytics-next/-/analytics-next-1.72.1.tgz#e09bc6a31de004986c1822ac39c69b419135c75e"
+  integrity sha512-OeCe/jMAWxC5a1fY8RRszIzG7zevmkRHEaUQZMXskPFPWu2fB9r8A/JeZtoX9+kKlNg2SMMAdsnIRxsvaHIkMA==
+  dependencies:
+    "@lukeed/uuid" "^2.0.0"
+    "@segment/analytics-core" "1.6.0"
+    "@segment/analytics-generic-utils" "1.2.0"
+    "@segment/analytics.js-video-plugins" "^0.2.1"
+    "@segment/facade" "^3.4.9"
+    dset "^3.1.2"
+    js-cookie "3.0.1"
+    node-fetch "^2.6.7"
+    tslib "^2.4.1"
+    unfetch "^4.1.0"
+
+"@segment/analytics.js-video-plugins@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@segment/analytics.js-video-plugins/-/analytics.js-video-plugins-0.2.1.tgz#3596fa3887dcd9df5978dc566edf4a0aea2a9b1e"
+  integrity sha512-lZwCyEXT4aaHBLNK433okEKdxGAuyrVmop4BpQqQSJuRz0DglPZgd9B/XjiiWs1UyOankg2aNYMN3VcS8t4eSQ==
+  dependencies:
+    unfetch "^3.1.1"
+
+"@segment/backstage-plugin-analytics-module-segment@link:plugins/analytics-module-segment":
+  version "0.0.0"
+  dependencies:
+    "@segment/analytics-next" "^1.72.1"
+
 "@segment/backstage-plugin-proxy-sigv4-backend@link:plugins/proxy-sigv4-backend":
   version "0.2.0"
   dependencies:
@@ -7001,6 +7076,28 @@
     express "^4.17.1"
     express-promise-router "^4.1.0"
     node-fetch "^2.6.7"
+
+"@segment/facade@^3.4.9":
+  version "3.4.10"
+  resolved "https://registry.yarnpkg.com/@segment/facade/-/facade-3.4.10.tgz#118fab29cf2250d3128f9b2a16d6ec76f86e3710"
+  integrity sha512-xVQBbB/lNvk/u8+ey0kC/+g8pT3l0gCT8O2y9Z+StMMn3KAFAQ9w8xfgef67tJybktOKKU7pQGRPolRM1i1pdA==
+  dependencies:
+    "@segment/isodate-traverse" "^1.1.1"
+    inherits "^2.0.4"
+    new-date "^1.0.3"
+    obj-case "0.2.1"
+
+"@segment/isodate-traverse@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@segment/isodate-traverse/-/isodate-traverse-1.1.1.tgz#37e1a68b5e48a841260145f1be86d342995dfc64"
+  integrity sha512-+G6e1SgAUkcq0EDMi+SRLfT48TNlLPF3QnSgFGVs0V9F3o3fq/woQ2rHFlW20W0yy5NnCUH0QGU3Am2rZy/E3w==
+  dependencies:
+    "@segment/isodate" "^1.0.3"
+
+"@segment/isodate@1.0.3", "@segment/isodate@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@segment/isodate/-/isodate-1.0.3.tgz#f44e8202d5edd277ce822785239474b2c9411d4a"
+  integrity sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A==
 
 "@sigstore/bundle@^1.1.0":
   version "1.1.0"
@@ -9959,6 +10056,7 @@ apg-lite@^1.0.3:
     "@backstage/theme" "^0.5.6"
     "@material-ui/core" "^4.12.2"
     "@material-ui/icons" "^4.9.1"
+    "@segment/backstage-plugin-analytics-module-segment" "link:plugins/analytics-module-segment"
     history "^5.0.0"
     react "^18.0.2"
     react-dom "^18.0.2"
@@ -16552,6 +16650,11 @@ js-base64@^3.6.0:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.7.tgz#e51b84bf78fbf5702b9541e2cb7bfcb893b43e79"
   integrity sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==
 
+js-cookie@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
+  integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
+
 js-cookie@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
@@ -18844,6 +18947,13 @@ neotraverse@=0.6.18:
   resolved "https://registry.yarnpkg.com/neotraverse/-/neotraverse-0.6.18.tgz#abcb33dda2e8e713cf6321b29405e822230cdb30"
   integrity sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==
 
+new-date@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/new-date/-/new-date-1.0.3.tgz#a5956086d3f5ed43d0b210d87a10219ccb7a2326"
+  integrity sha512-0fsVvQPbo2I18DT2zVHpezmeeNYV2JaJSrseiHLc17GNOxJzUdx5mvSigPu8LtIfZSij5i1wXnXFspEs2CD6hA==
+  dependencies:
+    "@segment/isodate" "1.0.3"
+
 nimma@0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/nimma/-/nimma-0.2.2.tgz#48d00f837d17b4baa23beec22ac1380f152f15ef"
@@ -19279,6 +19389,11 @@ oauth@0.9.x:
   version "0.9.15"
   resolved "https://registry.yarnpkg.com/oauth/-/oauth-0.9.15.tgz#bd1fefaf686c96b75475aed5196412ff60cfb9c1"
   integrity sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==
+
+obj-case@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/obj-case/-/obj-case-0.2.1.tgz#13a554d04e5ca32dfd9d566451fd2b0e11007f1a"
+  integrity sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg==
 
 object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
@@ -21304,7 +21419,7 @@ react-window@^1.8.10, react-window@^1.8.6:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@^18.0.2:
+"react@^16.13.1 || ^17.0.0 || ^18.0.0", react@^18.0.2:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
@@ -23997,6 +24112,16 @@ undici@^5.28.4:
   integrity sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==
   dependencies:
     "@fastify/busboy" "^2.0.0"
+
+unfetch@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-3.1.2.tgz#dc271ef77a2800768f7b459673c5604b5101ef77"
+  integrity sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw==
+
+unfetch@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
+  integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Description

This PR implements a [custom Backstage analytics module plugin](https://backstage.io/docs/plugins/analytics/#writing-integrations) specifically geared around Segment analytics.

Seeing as this is Segment's open-source backstage plugin library, it seems prudent that Segment contributes an analytics library for our own product!

This is definitely a v0.1.0 version, with much more support possibly planned for the future:
* registering [groups](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/#group) based on user ownership refs
* allowing for custom event mapping logic

For now, we simply look at the core supported [key events](https://backstage.io/docs/plugins/analytics#key-events) and primarily handle the following:
* `navigate` events to [analytics.page()](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/#page) events
* `create` events as [analytics.track()](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/#track) events where the event name is the name of the thing created (e.g. the software template executed)
* all other events as `analytics.track()` events with the action as the event name
