### PR TITLE
chore(release/proxy-sigv4-backend): publish v0.3.0

### DIFF
--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -3,16 +3,9 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# 0.3.0 (2024-08-30)
+# 0.2.0 (2024-08-30)
 
 ### Features
 
-- **proxy-sigv4-backend:** migrate to aws-sdk v3 for js and remove deprecations ([#10](https://github.com/segmentio/segment-backstage-plugins/issues/10)) ([cac1d4a](https://github.com/segmentio/segment-backstage-plugins/commit/cac1d4a89015af48fcf1e2e274dcf330858e57cd))
 - upgrade dependencies for backstage 1.30.3 ([#9](https://github.com/segmentio/segment-backstage-plugins/issues/9)) ([f4571f5](https://github.com/segmentio/segment-backstage-plugins/commit/f4571f5a88f32a7a84715235ea9caa0d6d2e1994))
-
-# 0.2.0 (2024-04-05)
-
-### Features
-
-- **proxy-sigv4-backend:** add new backend system support ([#4](https://github.com/segmentio/segment-backstage-plugins/issues/4)) ([f497502](https://github.com/segmentio/segment-backstage-plugins/commit/f497502c4306d49c2d600ed393d6b97ab8d40b16))
 - upgrade to backstage 1.25.2 ([#4](https://github.com/segmentio/segment-backstage-plugins/issues/4)) ([04bd05b](https://github.com/segmentio/segment-backstage-plugins/commit/04bd05b6d31ea9a59c0261241a97b8c5efac0c08))

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "bundled": true,
   "backstage": {
@@ -14,6 +14,8 @@
     "lint": "backstage-cli package lint"
   },
   "dependencies": {
+    "@backstage-community/plugin-github-actions": "^0.6.16",
+    "@backstage-community/plugin-tech-radar": "^0.7.4",
     "@backstage/app-defaults": "^1.5.10",
     "@backstage/catalog-model": "^1.6.0",
     "@backstage/cli": "^0.27.0",
@@ -44,9 +46,7 @@
     "react-dom": "^18.0.2",
     "react-router": "^6.3.0",
     "react-router-dom": "^6.3.0",
-    "react-use": "^17.2.4",
-    "@backstage-community/plugin-github-actions": "^0.6.16",
-    "@backstage-community/plugin-tech-radar": "^0.7.4"
+    "react-use": "^17.2.4"
   },
   "devDependencies": {
     "@backstage/test-utils": "^1.5.10",

--- a/packages/backend/CHANGELOG.md
+++ b/packages/backend/CHANGELOG.md
@@ -3,16 +3,9 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# 0.3.0 (2024-08-30)
+# 0.2.0 (2024-08-30)
 
 ### Features
 
-- **proxy-sigv4-backend:** migrate to aws-sdk v3 for js and remove deprecations ([#10](https://github.com/segmentio/segment-backstage-plugins/issues/10)) ([cac1d4a](https://github.com/segmentio/segment-backstage-plugins/commit/cac1d4a89015af48fcf1e2e274dcf330858e57cd))
 - upgrade dependencies for backstage 1.30.3 ([#9](https://github.com/segmentio/segment-backstage-plugins/issues/9)) ([f4571f5](https://github.com/segmentio/segment-backstage-plugins/commit/f4571f5a88f32a7a84715235ea9caa0d6d2e1994))
-
-# 0.2.0 (2024-04-05)
-
-### Features
-
-- **proxy-sigv4-backend:** add new backend system support ([#4](https://github.com/segmentio/segment-backstage-plugins/issues/4)) ([f497502](https://github.com/segmentio/segment-backstage-plugins/commit/f497502c4306d49c2d600ed393d6b97ab8d40b16))
 - upgrade to backstage 1.25.2 ([#4](https://github.com/segmentio/segment-backstage-plugins/issues/4)) ([04bd05b](https://github.com/segmentio/segment-backstage-plugins/commit/04bd05b6d31ea9a59c0261241a97b8c5efac0c08))

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/plugins/proxy-sigv4-backend/package.json
+++ b/plugins/proxy-sigv4-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/backstage-plugin-proxy-sigv4-backend",
   "description": "Backstage backend plugin that configures endpoints for signing and proxying HTTP requests with AWS SigV4",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
Generating CHANGELOG and preparing a new version release for the `proxy-sigv4-backend` package.

Following https://github.com/segmentio/segment-backstage-plugins/pull/5 as prior art, but some changes will need to take place going forward.

Since the original released include `--no-git-tag-version`, we lose CHANGELOG history tracking, so every CHANGELOG is generated _with all commits_. I manually modified this version so that we can have a proper CHANGELOG history.

We'll need to resolve what tagging looks like on releases for this plugin so that we don't duplicate things in the CHANGELOG moving forward.

Once this is merged, then I will run the `npx lerna publish from-package --no-verify-access` command to officially publish the new version.