### PR TITLE
build: resolve proxy-sigv4 plugin requirements for release

### DIFF
--- a/plugins/proxy-sigv4-backend/package.json
+++ b/plugins/proxy-sigv4-backend/package.json
@@ -12,7 +12,11 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "backend-plugin"
+    "role": "backend-plugin",
+    "pluginId": "proxy-sigv4",
+    "pluginPackages": [
+      "@segment/backstage-plugin-proxy-sigv4-backend"
+    ]
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Attempting to release failed with
```
Error: Plugin package @segment/backstage-plugin-proxy-sigv4-backend is missing a backstage.pluginId, please run 'backstage-cli repo fix --publish'
```

This should fix things up.