### PR TITLE
build: force bump to release types

### DIFF
--- a/plugins/proxy-sigv4-backend/CHANGELOG.md
+++ b/plugins/proxy-sigv4-backend/CHANGELOG.md
@@ -5,6 +5,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # 0.3.0 (2024-08-30)
 
+_Release only to fix missing `dist/index.d.ts` definitions_
+
+# 0.3.0 (2024-08-30)
+
 ### Features
 
 - **proxy-sigv4-backend:** migrate to aws-sdk v3 for js and remove deprecations ([#10](https://github.com/segmentio/segment-backstage-plugins/issues/10)) ([cac1d4a](https://github.com/segmentio/segment-backstage-plugins/commit/cac1d4a89015af48fcf1e2e274dcf330858e57cd))

--- a/plugins/proxy-sigv4-backend/package.json
+++ b/plugins/proxy-sigv4-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/backstage-plugin-proxy-sigv4-backend",
   "description": "Backstage backend plugin that configures endpoints for signing and proxying HTTP requests with AWS SigV4",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
The 3.0.0 release neglected to include the `dist/index.d.ts` file in the package, which caused downstream consumers to experience issues with TypeScript type checking. This PR bumps the version to 3.0.1 and includes the missing file in the package.

```
lerna success published @segment/backstage-plugin-proxy-sigv4-backend 0.3.1
lerna notice
lerna notice 📦  @segment/backstage-plugin-proxy-sigv4-backend@0.3.1
lerna notice === Tarball Contents ===
lerna notice 11.3kB LICENSE
lerna notice 7.5kB  dist/index.cjs.js
lerna notice 1.7kB  package.json
lerna notice 14.5kB dist/index.cjs.js.map
lerna notice 6.3kB  README.md
lerna notice 1.0kB  config.d.ts
lerna notice 535B   dist/index.d.ts
lerna notice === Tarball Details ===
lerna notice name:          @segment/backstage-plugin-proxy-sigv4-backend
lerna notice version:       0.3.1
lerna notice filename:      segment-backstage-plugin-proxy-sigv4-backend-0.3.1.tgz
lerna notice package size:  13.6 kB
lerna notice unpacked size: 42.8 kB
lerna notice shasum:        8bbc139c85ccfa42086ff9e3bef24a3890464a7b
lerna notice integrity:     sha512-3rDSVic3kcxx7[...]/PmRPPs6ooF0A==
lerna notice total files:   7
lerna notice
Successfully published:
 - @segment/backstage-plugin-proxy-sigv4-backend@0.3.1
```

Apparently running `yarn build` from the root of the repo decided to _remove `dist/index.d.ts`_ from the package for some reason. We should dig into that since it is another trap waiting to happen.

