### PR TITLE
build: do not run lerna build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:backend": "yarn workspace backend build",
     "build:all": "backstage-cli repo build --all",
     "build-image": "yarn workspace backend build-image",
-    "build": "lerna run build",
+    "build": "yarn build:all",
     "tsc": "tsc",
     "tsc:full": "tsc --skipLibCheck false --incremental false",
     "clean": "backstage-cli repo clean",


### PR DESCRIPTION
The previous `yarn build` command ran `lerna run build`, which was causing issues with the release process.

For some reason, `lerna run build` was **deleting `dist/index.d.ts`** files from the build public plugins, meaning on release that they would no longer include their type definitions.

Backstage does not even define a root `yarn build` anymore and `@backstage/create-app` [also no longer has this `lerna run build` step.](https://github.com/backstage/backstage/blob/140a61ab8db331ea4c13ab2a3b179cc4a6a23732/packages/create-app/templates/default-app/package.json.hbs#L8-L25)

For now, just make `yarn build` and `yarn build:all` equivalent since that is primary requirement for this repo.