### PR TITLE
fix(proxy-sigv4-backend): revert to old  body serialization to fix bug with body type

### DIFF
--- a/plugins/proxy-sigv4-backend/src/service/router.test.ts
+++ b/plugins/proxy-sigv4-backend/src/service/router.test.ts
@@ -224,7 +224,7 @@ describe('buildMiddleware', () => {
         expiration: new Date('2024-05-05T20:30:00Z'),
       });
 
-    // s
+    // starts the middleware and timer
     await buildMiddleware({
       logger,
       routePath: '/foo',

--- a/plugins/proxy-sigv4-backend/src/service/router.ts
+++ b/plugins/proxy-sigv4-backend/src/service/router.ts
@@ -189,10 +189,9 @@ export async function buildMiddleware(
         headers: requestHeaders,
       };
 
-      if (req.method !== 'GET' && req.method !== 'HEAD') {
-        request.body = req.is('application/json')
-          ? JSON.stringify(req.body)
-          : req.body;
+      // TODO: support other content types with bodies
+      if (req.is('application/json') && req.method !== 'GET') {
+        request.body = JSON.stringify(req.body);
       }
 
       aws4.sign(request, credentials);


### PR DESCRIPTION
When we migrated the AWS SDK version, I made a slight optimization on body serialization.

That turned out to be not good, so instead, revert back to what was there previously and follow up.