### PR TITLE
chore(release): run yarn tsc in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Run tsc
+        run: yarn tsc
+
       - name: Build
         run: NODE_ENV=production yarn build
 

--- a/.github/workflows/verify-build-and-tests.yml
+++ b/.github/workflows/verify-build-and-tests.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Lint
         run: yarn lint


### PR DESCRIPTION
Force a release with an updated workflow to run `yarn tsc` before build.